### PR TITLE
vectorstore: Fix in exists operator. Was working as null

### DIFF
--- a/langchain_postgres/vectorstores.py
+++ b/langchain_postgres/vectorstores.py
@@ -720,7 +720,7 @@ class PGVector(VectorStore):
                 self.EmbeddingStore.cmetadata,
                 field,
             )
-            return ~condition if filter_value else condition
+            return condition if filter_value else ~condition
         else:
             raise NotImplementedError()
 

--- a/tests/unit_tests/fixtures/filtering_test_cases.py
+++ b/tests/unit_tests/fixtures/filtering_test_cases.py
@@ -226,19 +226,19 @@ TYPE_5_FILTERING_TEST_CASES = [
 TYPE_6_FILTERING_TEST_CASES = [
     # These involve the special operator $exists
     (
-        {"happiness": {"$exists": True}},
+        {"happiness": {"$exists": False}},
         [],
     ),
     (
-        {"happiness": {"$exists": False}},
+        {"happiness": {"$exists": True}},
         [1, 2, 3],
     ),
     (
-        {"sadness": {"$exists": True}},
+        {"sadness": {"$exists": False}},
         [3],
     ),
     (
-        {"sadness": {"$exists": False}},
+        {"sadness": {"$exists": True}},
         [1, 2],
     ),
 ]


### PR DESCRIPTION
So... yeah I f***ed up. But this is the fix.

The $exists was working as the $null, but the rename implies also changing how the bool value is interpreted:

$exists: True (there is a tag, I don't care the value)
$exists: False (no tag in there)

ref: https://github.com/langchain-ai/langchain-postgres/pull/40