### PR TITLE
Add URL to source code to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ readme = "README.md"
 repository = "https://github.com/langchain-ai/langchain-postgres"
 license = "MIT"
 
+[tool.poetry.urls]
+"Source Code" = "https://github.com/langchain-ai/langchain-postgres/tree/master/langchain_postgres"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 langchain-core = ">=0.1.50,<0.3"


### PR DESCRIPTION
The  "Source Code" param was missing in the pyproject.toml. It is used to generate the package list in the LangChain [documentation](https://langchain-3amlg0zta-langchain.vercel.app/v0.2/docs/integrations/platforms/)