### PR TITLE
Dependencies: Add `greenlet` package to `test` dependency group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -726,8 +726,7 @@ version = "3.1.0"
 description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
-markers = "python_version < \"3.13\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
+groups = ["main", "test"]
 files = [
     {file = "greenlet-3.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a814dc3100e8a046ff48faeaa909e80cdb358411a3d6dd5293158425c684eda8"},
     {file = "greenlet-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a771dc64fa44ebe58d65768d869fcfb9060169d203446c1d446e844b62bdfdca"},
@@ -3413,4 +3412,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "2773b18ce59849abc67ba98fd284f10279f7bd577ac7b9617d4e7ce3516ed55a"
+content-hash = "61cd97d8122484f2b526b17cfc2b1e284a7d7e551508bdcbba52900d83cbadf5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ jupyterlab = "^3.6.1"
 optional = true
 
 [tool.poetry.group.test.dependencies]
+greenlet = "<4"
 pytest = "^7.4.3"
 pytest-asyncio = "^0.23.2"
 pytest-socket = "^0.7.0"


### PR DESCRIPTION
All async tests apparently need it. Otherwise:

```shell
pytest -vvv -k test_async_pgvector
```
```python
ValueError: the greenlet library is required to use this function. No module named 'greenlet'
```
