### PR TITLE
fix: Add setter for Chat Message History messages

### DIFF
--- a/langchain_postgres/chat_message_histories.py
+++ b/langchain_postgres/chat_message_histories.py
@@ -347,7 +347,7 @@ class PostgresChatMessageHistory(BaseChatMessageHistory):
 
     @messages.setter
     def messages(self, value: list[BaseMessage]) -> None:
-        """Clear the stored messages and appends a list of messages to the record in AlloyDB."""
+        """Clear the stored messages and appends a list of messages."""
         self.clear()
         self.add_messages(value)
 

--- a/langchain_postgres/chat_message_histories.py
+++ b/langchain_postgres/chat_message_histories.py
@@ -340,10 +340,16 @@ class PostgresChatMessageHistory(BaseChatMessageHistory):
         messages = messages_from_dict(items)
         return messages
 
-    @property  # type: ignore[override]
+    @property
     def messages(self) -> List[BaseMessage]:
         """The abstraction required a property."""
         return self.get_messages()
+
+    @messages.setter
+    def messages(self, value: list[BaseMessage]) -> None:
+        """Clear the stored messages and appends a list of messages to the record in AlloyDB."""
+        self.clear()
+        self.add_messages(value)
 
     def clear(self) -> None:
         """Clear the chat message history for the GIVEN session."""


### PR DESCRIPTION
Fixes mypy error:
langchain_postgres/chat_message_histories.py:344: error: Cannot override writeable attribute with read-only property  [override] Found 1 error in 1 file (checked 37 source files)