### PR TITLE
chore: Update PGVectorstore quickstart

### DIFF
--- a/examples/pg_vectorstore.ipynb
+++ b/examples/pg_vectorstore.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "from langchain_postgres import PGEngine\n",
     "\n",
-    "engine = PGEngine.from_connection_string(url=CONNECTION_STRING)"
+    "pg_engine = PGEngine.from_connection_string(url=CONNECTION_STRING)"
    ]
   },
   {

--- a/examples/pg_vectorstore.ipynb
+++ b/examples/pg_vectorstore.ipynb
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "irl7eMFnSPZr",
    "metadata": {
     "id": "irl7eMFnSPZr"
@@ -90,7 +90,7 @@
     "POSTGRES_PORT = \"6024\"  # @param {type: \"string\"}\n",
     "POSTGRES_DB = \"langchain\"  # @param {type: \"string\"}\n",
     "TABLE_NAME = \"vectorstore\"  # @param {type: \"string\"}\n",
-    "VECTOR_SIZE = 768  # @param {type: \"int\"}"
+    "VECTOR_SIZE = 1024  # @param {type: \"int\"}"
    ]
   },
   {
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,13 +178,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "id": "avlyHEMn6gzU"
    },
    "outputs": [],
    "source": [
-    "await engine.ainit_vectorstore_table(\n",
+    "await pg_engine.ainit_vectorstore_table(\n",
     "    table_name=TABLE_NAME,\n",
     "    vector_size=VECTOR_SIZE,\n",
     ")"
@@ -200,7 +200,7 @@
     "```python\n",
     "SCHEMA_NAME=\"my_schema\"\n",
     "\n",
-    "await engine.ainit_vectorstore_table(\n",
+    "await pg_engine.ainit_vectorstore_table(\n",
     "    table_name=TABLE_NAME,\n",
     "    vector_size=768,\n",
     "    schema_name=SCHEMA_NAME,    # Default: \"public\"\n",
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -231,7 +231,7 @@
    "source": [
     "from langchain_cohere import CohereEmbeddings\n",
     "\n",
-    "embedding = CohereEmbeddings()"
+    "embedding = CohereEmbeddings(model=\"embed-english-v3.0\")"
    ]
   },
   {
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "id": "z-AZyzAQ7bsf"
    },
@@ -254,7 +254,7 @@
     "from langchain_postgres import PGVectorStore\n",
     "\n",
     "store = await PGVectorStore.create(\n",
-    "    engine=engine,\n",
+    "    engine=pg_engine,\n",
     "    table_name=TABLE_NAME,\n",
     "    # schema_name=SCHEMA_NAME,\n",
     "    embedding_service=embedding,\n",
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,10 +298,9 @@
     "store_with_documents = await PGVectorStore.afrom_documents(\n",
     "    documents=docs,\n",
     "    ids=ids,\n",
-    "    engine=engine,\n",
+    "    engine=pg_engine,\n",
     "    table_name=TABLE_NAME,\n",
-    "    # schema_name=SCHEMA_NAME,\n",
-    "    embedding_service=embedding,\n",
+    "    embedding=embedding,\n",
     ")"
    ]
   },
@@ -389,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +453,7 @@
     "TABLE_NAME = \"vectorstore_custom\"\n",
     "# SCHEMA_NAME = \"my_schema\"\n",
     "\n",
-    "await engine.ainit_vectorstore_table(\n",
+    "await pg_engine.ainit_vectorstore_table(\n",
     "    table_name=TABLE_NAME,\n",
     "    # schema_name=SCHEMA_NAME,\n",
     "    vector_size=VECTOR_SIZE,\n",
@@ -464,7 +463,7 @@
     "\n",
     "# Initialize PGVectorStore\n",
     "custom_store = await PGVectorStore.create(\n",
-    "    engine=engine,\n",
+    "    engine=pg_engine,\n",
     "    table_name=TABLE_NAME,\n",
     "    # schema_name=SCHEMA_NAME,\n",
     "    embedding_service=embedding,\n",
@@ -578,7 +577,7 @@
     "\n",
     "# Initialize PGVectorStore\n",
     "custom_store = await PGVectorStore.create(\n",
-    "    engine=engine,\n",
+    "    engine=pg_engine,\n",
     "    table_name=TABLE_NAME,\n",
     "    # schema_name=SCHEMA_NAME,\n",
     "    embedding_service=embedding,\n",
@@ -685,7 +684,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/langchain_postgres/chat_message_histories.py
+++ b/langchain_postgres/chat_message_histories.py
@@ -2,6 +2,7 @@
 
 This client provides support for both sync and async via psycopg 3.
 """
+
 from __future__ import annotations
 
 import json

--- a/langchain_postgres/chat_message_histories.py
+++ b/langchain_postgres/chat_message_histories.py
@@ -2,7 +2,6 @@
 
 This client provides support for both sync and async via psycopg 3.
 """
-
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
chore: Update PGVectorstore quickstart

Changes:
- The instances where the variable `engine` is being used instead of `pg_engine`
- Added Cohere embedding model along with the right vector size for the model
- Change to use `embedding` parameter instead of `embedding_service` in vectorstore.afrom_documents

Fixes #180 