### PR TITLE
feat: support for Halfvec and Sparsevec vector types

### DIFF
--- a/langchain_postgres/v2/async_vectorstore.py
+++ b/langchain_postgres/v2/async_vectorstore.py
@@ -935,15 +935,15 @@ class AsyncPGVectorStore(VectorStore):
                     text(f"CREATE EXTENSION IF NOT EXISTS {index.extension_name}")
                 )
                 await conn.commit()
-        function = index.get_index_function()
 
+        operator_class = index.operator_class()
         filter = f"WHERE ({index.partial_indexes})" if index.partial_indexes else ""
         params = "WITH " + index.index_options()
         if name is None:
             if index.name is None:
                 index.name = self.table_name + DEFAULT_INDEX_NAME_SUFFIX
             name = index.name
-        stmt = f'CREATE INDEX {"CONCURRENTLY" if concurrently else ""} "{name}" ON "{self.schema_name}"."{self.table_name}" USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};'
+        stmt = f'CREATE INDEX {"CONCURRENTLY" if concurrently else ""} "{name}" ON "{self.schema_name}"."{self.table_name}" USING {index.index_type} ({self.embedding_column} {operator_class}) {params} {filter};'
 
         if concurrently:
             async with self.engine.connect() as conn:

--- a/langchain_postgres/v2/engine.py
+++ b/langchain_postgres/v2/engine.py
@@ -10,6 +10,7 @@ from sqlalchemy.engine import URL
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from .hybrid_search_config import HybridSearchConfig
+from .indexes import DEFAULT_VECTOR_TYPE, VectorType
 
 T = TypeVar("T")
 
@@ -150,6 +151,7 @@ class PGEngine:
         table_name: str,
         vector_size: int,
         *,
+        vector_type: VectorType = DEFAULT_VECTOR_TYPE,
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
@@ -166,6 +168,8 @@ class PGEngine:
         Args:
             table_name (str): The database table name.
             vector_size (int): Vector size for the embedding model to be used.
+            vector_type (VectorType): Type of the vector column to store embeddings.
+                Default: VectorType.VECTOR.
             schema_name (str): The schema name.
                 Default: "public".
             content_column (str): Name of the column to store document content.
@@ -194,6 +198,8 @@ class PGEngine:
         hybrid_search_default_column_name = content_column + "_tsv"
         content_column = self._escape_postgres_identifier(content_column)
         embedding_column = self._escape_postgres_identifier(embedding_column)
+        embedding_column_type = f"{vector_type.value}({vector_size})"
+
         if metadata_columns is None:
             metadata_columns = []
         else:
@@ -246,7 +252,7 @@ class PGEngine:
         query = f"""CREATE TABLE "{schema_name}"."{table_name}"(
             "{id_column_name}" {id_data_type} PRIMARY KEY,
             "{content_column}" TEXT NOT NULL,
-            "{embedding_column}" vector({vector_size}) NOT NULL
+            "{embedding_column}" {embedding_column_type} NOT NULL
             {hybrid_search_column}"""
         for column in metadata_columns:
             if isinstance(column, Column):
@@ -268,6 +274,7 @@ class PGEngine:
         table_name: str,
         vector_size: int,
         *,
+        vector_type: VectorType = DEFAULT_VECTOR_TYPE,
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
@@ -284,6 +291,8 @@ class PGEngine:
         Args:
             table_name (str): The database table name.
             vector_size (int): Vector size for the embedding model to be used.
+            vector_type (VectorType): Type of the vector column to store embeddings.
+                Default: VectorType.VECTOR.
             schema_name (str): The schema name.
                 Default: "public".
             content_column (str): Name of the column to store document content.
@@ -308,6 +317,7 @@ class PGEngine:
             self._ainit_vectorstore_table(
                 table_name,
                 vector_size,
+                vector_type=vector_type,
                 schema_name=schema_name,
                 content_column=content_column,
                 embedding_column=embedding_column,
@@ -325,6 +335,7 @@ class PGEngine:
         table_name: str,
         vector_size: int,
         *,
+        vector_type: VectorType = DEFAULT_VECTOR_TYPE,
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
@@ -341,6 +352,8 @@ class PGEngine:
         Args:
             table_name (str): The database table name.
             vector_size (int): Vector size for the embedding model to be used.
+            vector_type (VectorType): Type of the vector column to store embeddings.
+                Default: VectorType.VECTOR.
             schema_name (str): The schema name.
                 Default: "public".
             content_column (str): Name of the column to store document content.
@@ -365,6 +378,7 @@ class PGEngine:
             self._ainit_vectorstore_table(
                 table_name,
                 vector_size,
+                vector_type=vector_type,
                 schema_name=schema_name,
                 content_column=content_column,
                 embedding_column=embedding_column,

--- a/langchain_postgres/v2/indexes.py
+++ b/langchain_postgres/v2/indexes.py
@@ -15,19 +15,28 @@ from typing import Optional
 class StrategyMixin:
     operator: str
     search_function: str
-    index_function: str
+    operator_class_suffix: str
 
 
 class DistanceStrategy(StrategyMixin, enum.Enum):
     """Enumerator of the Distance strategies."""
 
-    EUCLIDEAN = "<->", "l2_distance", "vector_l2_ops"
-    COSINE_DISTANCE = "<=>", "cosine_distance", "vector_cosine_ops"
-    INNER_PRODUCT = "<#>", "inner_product", "vector_ip_ops"
+    EUCLIDEAN = "<->", "l2_distance", "l2_ops"
+    COSINE_DISTANCE = "<=>", "cosine_distance", "cosine_ops"
+    INNER_PRODUCT = "<#>", "inner_product", "ip_ops"
 
 
 DEFAULT_DISTANCE_STRATEGY: DistanceStrategy = DistanceStrategy.COSINE_DISTANCE
 DEFAULT_INDEX_NAME_SUFFIX: str = "langchainvectorindex"
+
+
+class VectorType(enum.Enum):
+    VECTOR = "vector"
+    HALFVEC = "halfvec"
+    SPARSEVEC = "sparsevec"
+
+
+DEFAULT_VECTOR_TYPE: VectorType = VectorType.VECTOR
 
 
 def validate_identifier(identifier: str) -> None:
@@ -47,6 +56,8 @@ class BaseIndex(ABC):
         index_type (str): A string identifying the type of index. Defaults to "base".
         distance_strategy (DistanceStrategy): The strategy used to calculate distances
             between vectors in the index. Defaults to DistanceStrategy.COSINE_DISTANCE.
+        vector_type (VectorType): The type of vector column,
+            on which the index will be created. Defaults to VectorType.VECTOR
         partial_indexes (Optional[list[str]]): A list of names of partial indexes. Defaults to None.
         extension_name (Optional[str]): The name of the extension to be created for the index, if any. Defaults to None.
     """
@@ -56,6 +67,7 @@ class BaseIndex(ABC):
     distance_strategy: DistanceStrategy = field(
         default_factory=lambda: DistanceStrategy.COSINE_DISTANCE
     )
+    vector_type: VectorType = DEFAULT_VECTOR_TYPE
     partial_indexes: Optional[list[str]] = None
     extension_name: Optional[str] = None
 
@@ -66,8 +78,11 @@ class BaseIndex(ABC):
             "index_options method must be implemented by subclass"
         )
 
-    def get_index_function(self) -> str:
-        return self.distance_strategy.index_function
+    def operator_class(self) -> str:
+        """Returns index operator class, based on vector type and distance strategy."""
+        return (
+            f"{self.vector_type.value}_{self.distance_strategy.operator_class_suffix}"
+        )
 
     def __post_init__(self) -> None:
         """Check if initialization parameters are valid.

--- a/tests/unit_tests/v2/test_indexes.py
+++ b/tests/unit_tests/v2/test_indexes.py
@@ -8,6 +8,7 @@ from langchain_postgres.v2.indexes import (
     HNSWQueryOptions,
     IVFFlatIndex,
     IVFFlatQueryOptions,
+    VectorType,
 )
 
 
@@ -16,15 +17,50 @@ class TestPGIndex:
     def test_distance_strategy(self) -> None:
         assert DistanceStrategy.EUCLIDEAN.operator == "<->"
         assert DistanceStrategy.EUCLIDEAN.search_function == "l2_distance"
-        assert DistanceStrategy.EUCLIDEAN.index_function == "vector_l2_ops"
+        assert DistanceStrategy.EUCLIDEAN.operator_class_suffix == "l2_ops"
 
         assert DistanceStrategy.COSINE_DISTANCE.operator == "<=>"
         assert DistanceStrategy.COSINE_DISTANCE.search_function == "cosine_distance"
-        assert DistanceStrategy.COSINE_DISTANCE.index_function == "vector_cosine_ops"
+        assert DistanceStrategy.COSINE_DISTANCE.operator_class_suffix == "cosine_ops"
 
         assert DistanceStrategy.INNER_PRODUCT.operator == "<#>"
         assert DistanceStrategy.INNER_PRODUCT.search_function == "inner_product"
-        assert DistanceStrategy.INNER_PRODUCT.index_function == "vector_ip_ops"
+        assert DistanceStrategy.INNER_PRODUCT.operator_class_suffix == "ip_ops"
+
+    @pytest.mark.parametrize(
+        "vector_type, distance_strategy, expected",
+        [
+            (
+                VectorType.VECTOR,
+                DistanceStrategy.COSINE_DISTANCE,
+                "vector_cosine_ops",
+            ),
+            (VectorType.VECTOR, DistanceStrategy.EUCLIDEAN, "vector_l2_ops"),
+            (VectorType.VECTOR, DistanceStrategy.INNER_PRODUCT, "vector_ip_ops"),
+            (
+                VectorType.HALFVEC,
+                DistanceStrategy.COSINE_DISTANCE,
+                "halfvec_cosine_ops",
+            ),
+            (VectorType.HALFVEC, DistanceStrategy.EUCLIDEAN, "halfvec_l2_ops"),
+            (VectorType.HALFVEC, DistanceStrategy.INNER_PRODUCT, "halfvec_ip_ops"),
+            (
+                VectorType.SPARSEVEC,
+                DistanceStrategy.COSINE_DISTANCE,
+                "sparsevec_cosine_ops",
+            ),
+            (VectorType.SPARSEVEC, DistanceStrategy.EUCLIDEAN, "sparsevec_l2_ops"),
+            (VectorType.SPARSEVEC, DistanceStrategy.INNER_PRODUCT, "sparsevec_ip_ops"),
+        ],
+    )
+    def test_operator_class_by_vector_type(
+        self,
+        vector_type: VectorType,
+        distance_strategy: DistanceStrategy,
+        expected: str,
+    ) -> None:
+        idx = HNSWIndex(vector_type=vector_type, distance_strategy=distance_strategy)
+        assert idx.operator_class() == expected
 
     def test_hnsw_index(self) -> None:
         index = HNSWIndex(name="test_index", m=32, ef_construction=128)
@@ -32,6 +68,7 @@ class TestPGIndex:
         assert index.m == 32
         assert index.ef_construction == 128
         assert index.index_options() == "(m = 32, ef_construction = 128)"
+        assert index.operator_class() == "vector_cosine_ops"
 
     def test_hnsw_query_options(self) -> None:
         options = HNSWQueryOptions(ef_search=80)
@@ -50,6 +87,7 @@ class TestPGIndex:
         assert index.index_type == "ivfflat"
         assert index.lists == 200
         assert index.index_options() == "(lists = 200)"
+        assert index.operator_class() == "vector_cosine_ops"
 
     def test_ivfflat_query_options(self) -> None:
         options = IVFFlatQueryOptions(probes=2)

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ wheels = [
 
 [[package]]
 name = "langchain-postgres"
-version = "0.0.15"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ wheels = [
 
 [[package]]
 name = "langchain-postgres"
-version = "0.0.14"
+version = "0.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
This PR adds full support for pgvector’s [Halfvec](https://github.com/pgvector/pgvector#halfvec-type) and [Sparsevec](https://github.com/pgvector/pgvector#sparsevec-type) vector types in both table and index creation. 
This adresses the 2 000-dimension limit of the standard vector type, not enough for models like text-embedding-3-large.

- `halfvec` stores embeddings as INT8 quantized values and supports indexing up to 16 000 dimensions.
- `sparsevec` stores sparse embeddings and also supports up to 16 000 dimensions.