### PR TITLE
fix: Use JSONB for metadata column instead of JSON

### DIFF
--- a/langchain_postgres/v2/engine.py
+++ b/langchain_postgres/v2/engine.py
@@ -256,7 +256,7 @@ class PGEngine:
                 nullable = "NOT NULL" if not column["nullable"] else ""
                 query += f',\n"{column["name"]}" {column["data_type"]} {nullable}'
         if store_metadata:
-            query += f""",\n"{metadata_json_column}" JSON"""
+            query += f""",\n"{metadata_json_column}" JSONB"""
         query += "\n);"
 
         async with self._pool.connect() as conn:


### PR DESCRIPTION
This pull request updates the metadata column type from `JSON` to `JSONB` in the PGVector table creation logic.

### 📌 Motivation

The LangChain documentation recommends using the `JSONB` type for metadata storage due to its performance and indexing advantages. However, the current implementation defaults to `JSON`, which does not align with this guidance.

### ✅ Changes

Replaces:
```python
query += f""",\n"{metadata_json_column}" JSON"""
```
with
```python
query += f""",\n"{metadata_json_column}" JSONB"""
```
### 📎 Notes
This change does not affect existing tables.