### PR TITLE
Feature: Add Document Retrieval with Metadata Filtering

### DIFF
--- a/langchain_postgres/v2/vectorstores.py
+++ b/langchain_postgres/v2/vectorstores.py
@@ -853,6 +853,29 @@ class PGVectorStore(VectorStore):
         """Get documents by ids."""
         return await self._engine._run_as_async(self.__vs.aget_by_ids(ids=ids))
 
+    def get(
+        self,
+        filter: Optional[dict] = None,
+        k: Optional[int] = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        """
+        Retrieve documents from the collection using optional filters and parameters.
+
+        Args:
+            filter (Optional[dict]): A dictionary specifying filtering criteria for the query. Defaults to None.
+            k (Optional[int]): The maximum number of documents to retrieve. If None, retrieves all matching documents.
+            **kwargs (Any): Additional keyword arguments passed to the asynchronous `aget` method.
+
+        Returns:
+            list[Document]: A list of `Document` instances matching the filter criteria.
+
+        Raises:
+            Any exceptions raised by the underlying asynchronous method or the sync execution engine.
+        """
+
+        return self._engine._run_as_sync(self.__vs.aget(filter=filter, k=k, **kwargs))
+
     def get_by_ids(self, ids: Sequence[str]) -> list[Document]:
         """Get documents by ids."""
         return self._engine._run_as_sync(self.__vs.aget_by_ids(ids=ids))

--- a/tests/unit_tests/v2/test_async_pg_vectorstore_search.py
+++ b/tests/unit_tests/v2/test_async_pg_vectorstore_search.py
@@ -370,6 +370,19 @@ class TestVectorStoreSearch:
         )
         assert [doc.metadata["code"] for doc in docs] == expected_ids, test_filter
 
+    @pytest.mark.parametrize("test_filter, expected_ids", FILTERING_TEST_CASES)
+    async def test_vectorstore_get(
+        self,
+        vs_custom_filter: AsyncPGVectorStore,
+        test_filter: dict,
+        expected_ids: list[str],
+    ) -> None:
+        """Test end to end construction and filter."""
+        docs = await vs_custom_filter.aget(test_filter, k=5)
+        assert set([doc.metadata["code"] for doc in docs]) == set(
+            expected_ids
+        ), test_filter
+
     async def test_asimilarity_hybrid_search(self, vs: AsyncPGVectorStore) -> None:
         results = await vs.asimilarity_search(
             "foo", k=1, hybrid_search_config=HybridSearchConfig()

--- a/tests/unit_tests/v2/test_pg_vectorstore_search.py
+++ b/tests/unit_tests/v2/test_pg_vectorstore_search.py
@@ -429,6 +429,20 @@ class TestVectorStoreSearchSync:
         docs = vs_custom_filter_sync.similarity_search("meow", k=5, filter=test_filter)
         assert [doc.metadata["code"] for doc in docs] == expected_ids, test_filter
 
+    @pytest.mark.parametrize("test_filter, expected_ids", FILTERING_TEST_CASES)
+    def test_sync_vectorstore_get(
+        self,
+        vs_custom_filter_sync: PGVectorStore,
+        test_filter: dict,
+        expected_ids: list[str],
+    ) -> None:
+        """Test end to end construction and filter."""
+
+        docs = vs_custom_filter_sync.get(k=5, filter=test_filter)
+        assert set([doc.metadata["code"] for doc in docs]) == set(
+            expected_ids
+        ), test_filter
+
     @pytest.mark.parametrize("test_filter", NEGATIVE_TEST_CASES)
     def test_metadata_filter_negative_tests(
         self, vs_custom_filter_sync: PGVectorStore, test_filter: dict


### PR DESCRIPTION

This pull request introduces the methods get and aget like in ChromaDB to retrieve data by metadata.

### 🔧 Changes

- **Asynchronous Document Retrieval**: Implemented the `aget` method to asynchronously retrieve documents based on optional filters and parameters.
- **Synchronous Document Retrieval**: Added the `get` method for synchronous document retrieval, leveraging the asynchronous `aget` method.
- **Metadata Filtering**: Created the `__query_collection_with_filter` method to support filtering conditions in the SQL WHERE clause without similarity function
- **Test Cases**: Added unit tests for both asynchronous and synchronous document retrieval methods to ensure functionality and reliability.


### 📈 Impact

These changes let us retrieve the current content to get insights about the data in the database e.g. to find outdated content.
