### PR TITLE
PGVector --> PGVectorStore: get_table_name with the specified db schema 

### DIFF
--- a/langchain_postgres/v2/vectorstores.py
+++ b/langchain_postgres/v2/vectorstores.py
@@ -858,4 +858,4 @@ class PGVectorStore(VectorStore):
         return self._engine._run_as_sync(self.__vs.aget_by_ids(ids=ids))
 
     def get_table_name(self) -> str:
-        return self.__vs.table_name
+        return f"{self.__vs.schema_name}.{self.__vs.table_name}"

--- a/langchain_postgres/v2/vectorstores.py
+++ b/langchain_postgres/v2/vectorstores.py
@@ -858,4 +858,5 @@ class PGVectorStore(VectorStore):
         return self._engine._run_as_sync(self.__vs.aget_by_ids(ids=ids))
 
     def get_table_name(self) -> str:
-        return f"{self.__vs.schema_name}.{self.__vs.table_name}"
+        """Get the table name in the format "schema_name.table_name"."""
+        return self.__vs.schema_name + "." + self.__vs.table_name

--- a/tests/unit_tests/v2/test_pg_vectorstore.py
+++ b/tests/unit_tests/v2/test_pg_vectorstore.py
@@ -15,9 +15,10 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from langchain_postgres import Column, PGEngine, PGVectorStore
 from tests.utils import VECTORSTORE_CONNECTION_STRING as CONNECTION_STRING
 
-DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
-DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4())
-CUSTOM_TABLE = "test-table-custom" + str(uuid.uuid4())
+DEFAULT_SCHEMA = "public"
+DEFAULT_TABLE = DEFAULT_SCHEMA + "." + "test_table" + str(uuid.uuid4())
+DEFAULT_TABLE_SYNC = DEFAULT_SCHEMA + "." +  "test_table_sync" + str(uuid.uuid4())
+CUSTOM_TABLE = DEFAULT_SCHEMA + "." + "test-table-custom" + str(uuid.uuid4())
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)


### PR DESCRIPTION
The internal `__amigrate_pgvector_collection` fails to select the table if it is in a custom db schema.

This fix will help who wants to upgrade (to `v0.0.14+`) .

Also, I have added DEFAULT_SCHEMA to `test_pg_vectorstore.py`.