### PR TITLE
fix: Fix hybrid search bugs

### DIFF
--- a/langchain_postgres/v2/async_vectorstore.py
+++ b/langchain_postgres/v2/async_vectorstore.py
@@ -583,13 +583,13 @@ class AsyncPGVectorStore(VectorStore):
         hybrid_search_config = kwargs.get(
             "hybrid_search_config", self.hybrid_search_config
         )
-    
+
         final_k = k if k is not None else self.k
-    
+
         dense_limit = final_k
         if hybrid_search_config:
             dense_limit = hybrid_search_config.primary_top_k
-    
+
         operator = self.distance_strategy.operator
         search_function = self.distance_strategy.search_function
 
@@ -636,7 +636,7 @@ class AsyncPGVectorStore(VectorStore):
                 result = await conn.execute(text(dense_query_stmt), param_dict)
                 result_map = result.mappings()
                 dense_results = result_map.fetchall()
-    
+
         fts_query = (
             hybrid_search_config.fts_query
             if hybrid_search_config and hybrid_search_config.fts_query


### PR DESCRIPTION
This PR fixes the 2nd Major issue in https://github.com/langchain-ai/langchain-postgres/issues/234, related to Configuration and Querying Issues

Issue breakdown:
-
**Inconsistent k Parameter:** For hybrid searches, the dense search LIMIT was tied to the final k parameter, while the sparse search used its own secondary_top_k. 
**Late Initialization of HybridSearchConfig:** The HybridSearchConfig was initialized after the k parameter was calculated, which could lead to incorrect behavior if the config was passed dynamically via `kwargs`.

Overview of the changes:
-
1. The __query_collection method now uses a separate `dense_limit` for the dense search query.
If HybridSearchConfig is active, dense_limit is set to primary_top_k. For dense-only searches, dense_limit defaults to the final k value, preserving the existing behavior.

2. The hybrid_search_config is now initialized at the beginning of `__query_collection`, ensuring that any `kwargs` overrides are handled before `k` or `dense_limit` are calculated.
