### PR TITLE
Fix incorrect connection string format in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_postgres import PGEngine, PGVectorStore
 
 # Replace the connection string with your own Postgres connection string
-CONNECTION_STRING = "postgresql+psycopg3://langchain:langchain@localhost:6024/langchain"
+CONNECTION_STRING = "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
 engine = PGEngine.from_connection_string(url=CONNECTION_STRING)
 
 # Replace the vector size with your own vector size


### PR DESCRIPTION
The connection string example in README.md is incorrect.

Currently, README.md shows:
```python
CONNECTION_STRING = "postgresql+psycopg3://langchain:langchain@localhost:6024/langchain"
```

However, this format causes the following error:
```
NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgresql.psycopg3
```

The actual example files (`examples/vectorstore.ipynb`, `examples/pg_vectorstore.ipynb`, etc.) use the correct format `postgresql+psycopg://`, which works correctly.

The `examples/vectorstore.ipynb` also explicitly states: "the driver name is `psycopg` not `psycopg3`, but it'll use `psycopg3`."

**Proposed fix:**
Line 46 in README.md should be changed from:
```python
CONNECTION_STRING = "postgresql+psycopg3://langchain:langchain@localhost:6024/langchain"
```

to:
```python
CONNECTION_STRING = "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
```