### PR TITLE
fix: reindex&drop_index without schema

### DIFF
--- a/langchain_postgres/v2/async_vectorstore.py
+++ b/langchain_postgres/v2/async_vectorstore.py
@@ -957,7 +957,7 @@ class AsyncPGVectorStore(VectorStore):
     async def areindex(self, index_name: Optional[str] = None) -> None:
         """Re-index the vector store table."""
         index_name = index_name or self.table_name + DEFAULT_INDEX_NAME_SUFFIX
-        query = f'REINDEX INDEX "{index_name}";'
+        query = f'REINDEX INDEX "{self.schema_name}"."{index_name}";'
         async with self.engine.connect() as conn:
             await conn.execute(text(query))
             await conn.commit()
@@ -968,7 +968,7 @@ class AsyncPGVectorStore(VectorStore):
     ) -> None:
         """Drop the vector index."""
         index_name = index_name or self.table_name + DEFAULT_INDEX_NAME_SUFFIX
-        query = f'DROP INDEX IF EXISTS "{index_name}";'
+        query = f'DROP INDEX IF EXISTS "{self.schema_name}"."{index_name}";'
         async with self.engine.connect() as conn:
             await conn.execute(text(query))
             await conn.commit()


### PR DESCRIPTION
### Summary

When a database schema is specified, areindex and adrop_vector_index in AsyncPGVectorStore do not take effect.

Fixes: #269 