### PR TITLE
feat: add ltree filtering operators to v2 vector store

### DIFF
--- a/langchain_postgres/v2/async_vectorstore.py
+++ b/langchain_postgres/v2/async_vectorstore.py
@@ -49,11 +49,11 @@ TEXT_OPERATORS = {
 LOGICAL_OPERATORS = {"$and", "$or", "$not"}
 
 LTREE_OPERATORS = {
-    "$ancestor",  # field @> value::ltree  (field is ancestor-of-or-equal-to value)
-    "$descendant",  # field <@ value::ltree  (field is descendant-of-or-equal-to value)
-    "$lquery",  # field ~ value::lquery  (field matches lquery pattern)
-    "$lquery_any",  # field ? ARRAY[...]::lquery[]  (field matches any lquery)
-    "$ltxtquery",  # field @ value::ltxtquery  (field matches ltxtquery)
+    "$ancestor",    # field @> CAST(value AS ltree)   (field is ancestor-of-or-equal-to value)
+    "$descendant",  # field <@ CAST(value AS ltree)   (field is descendant-of-or-equal-to value)
+    "$lquery",      # field ~ CAST(value AS lquery)   (field matches lquery pattern)
+    "$lquery_any",  # field ? ARRAY[CAST(...)]        (field matches any lquery in list)
+    "$ltxtquery",   # field @ CAST(value AS ltxtquery)(field matches ltxtquery expression)
 }
 
 SUPPORTED_OPERATORS = (

--- a/langchain_postgres/v2/async_vectorstore.py
+++ b/langchain_postgres/v2/async_vectorstore.py
@@ -48,11 +48,20 @@ TEXT_OPERATORS = {
 
 LOGICAL_OPERATORS = {"$and", "$or", "$not"}
 
+LTREE_OPERATORS = {
+    "$ancestor",  # field @> value::ltree  (field is ancestor-of-or-equal-to value)
+    "$descendant",  # field <@ value::ltree  (field is descendant-of-or-equal-to value)
+    "$lquery",  # field ~ value::lquery  (field matches lquery pattern)
+    "$lquery_any",  # field ? ARRAY[...]::lquery[]  (field matches any lquery)
+    "$ltxtquery",  # field @ value::ltxtquery  (field matches ltxtquery)
+}
+
 SUPPORTED_OPERATORS = (
     set(COMPARISONS_TO_NATIVE)
     .union(TEXT_OPERATORS)
     .union(LOGICAL_OPERATORS)
     .union(SPECIAL_CASED_OPERATORS)
+    .union(LTREE_OPERATORS)
 )
 
 PYTHON_TO_POSTGRES_TYPE_MAP = {
@@ -1264,7 +1273,7 @@ class AsyncPGVectorStore(VectorStore):
         ):
             field_selector = f"{self.metadata_json_column}.{field_selector}"
 
-        if "." in field_selector:
+        if "." in field_selector and operator not in LTREE_OPERATORS:
             field_selector = "->".join(
                 field_split
                 if ind == 0
@@ -1281,6 +1290,14 @@ class AsyncPGVectorStore(VectorStore):
                 raise ValueError(f"Unsupported type: {filter_value_type}")
             if postgres_type != "TEXT" and operator != "$exists":
                 field_selector = f"({field_selector})::{postgres_type}"
+        elif "." in field_selector:  # ltree operator on a JSON-stored field
+            field_selector = "->".join(
+                field_split
+                if ind == 0
+                else f"{'>' if ind == field_selector.count('.') else ''}'{field_split}'"
+                for ind, field_split in enumerate(field_selector.split("."))
+            )
+            # The ltree block below will apply the ::ltree cast
 
         suffix_id = str(uuid.uuid4()).split("-")[0]
         if operator in COMPARISONS_TO_NATIVE:
@@ -1346,6 +1363,61 @@ class AsyncPGVectorStore(VectorStore):
                     return f"({field_selector} IS NOT NULL)", {}
                 else:
                     return f"({field_selector} IS NULL)", {}
+        elif operator in LTREE_OPERATORS:
+            if operator == "$lquery_any":
+                if not isinstance(filter_value, list):
+                    raise ValueError(
+                        f"Expected a list of lquery strings for $lquery_any "
+                        f"operator, but got: {type(filter_value)}"
+                    )
+                for item in filter_value:
+                    if not isinstance(item, str):
+                        raise ValueError(
+                            f"Expected all values in $lquery_any to be strings, "
+                            f"but got: {type(item)} for value: {item}"
+                        )
+            else:
+                if not isinstance(filter_value, str):
+                    raise ValueError(
+                        f"Expected a string value for {operator} operator, "
+                        f"but got: {type(filter_value)}"
+                    )
+
+            # For JSON-stored fields (->> returns text), cast to ltree for comparison
+            effective_field_selector = (
+                f"({field_selector})::ltree"
+                if "->>" in field_selector
+                else field_selector
+            )
+
+            param_name = f"{field_param_prefix}_{operator.replace('$', '')}_{suffix_id}"
+
+            if operator == "$ancestor":
+                return (
+                    f"({effective_field_selector} @> :{param_name}::ltree)",
+                    {param_name: filter_value},
+                )
+            elif operator == "$descendant":
+                return (
+                    f"({effective_field_selector} <@ :{param_name}::ltree)",
+                    {param_name: filter_value},
+                )
+            elif operator == "$lquery":
+                return (
+                    f"({effective_field_selector} ~ :{param_name}::lquery)",
+                    {param_name: filter_value},
+                )
+            elif operator == "$lquery_any":
+                placeholders = ", ".join(
+                    [f":{param_name}_{i}::lquery" for i in range(len(filter_value))]
+                )
+                params = {f"{param_name}_{i}": v for i, v in enumerate(filter_value)}
+                return f"({effective_field_selector} ? ARRAY[{placeholders}])", params
+            else:  # operator == "$ltxtquery"
+                return (
+                    f"({effective_field_selector} @ :{param_name}::ltxtquery)",
+                    {param_name: filter_value},
+                )
         else:
             raise NotImplementedError()
 

--- a/langchain_postgres/v2/async_vectorstore.py
+++ b/langchain_postgres/v2/async_vectorstore.py
@@ -1394,28 +1394,31 @@ class AsyncPGVectorStore(VectorStore):
 
             if operator == "$ancestor":
                 return (
-                    f"({effective_field_selector} @> :{param_name}::ltree)",
+                    f"({effective_field_selector} @> CAST(:{param_name} AS ltree))",
                     {param_name: filter_value},
                 )
             elif operator == "$descendant":
                 return (
-                    f"({effective_field_selector} <@ :{param_name}::ltree)",
+                    f"({effective_field_selector} <@ CAST(:{param_name} AS ltree))",
                     {param_name: filter_value},
                 )
             elif operator == "$lquery":
                 return (
-                    f"({effective_field_selector} ~ :{param_name}::lquery)",
+                    f"({effective_field_selector} ~ CAST(:{param_name} AS lquery))",
                     {param_name: filter_value},
                 )
             elif operator == "$lquery_any":
                 placeholders = ", ".join(
-                    [f":{param_name}_{i}::lquery" for i in range(len(filter_value))]
+                    [
+                        f"CAST(:{param_name}_{i} AS lquery)"
+                        for i in range(len(filter_value))
+                    ]
                 )
                 params = {f"{param_name}_{i}": v for i, v in enumerate(filter_value)}
                 return f"({effective_field_selector} ? ARRAY[{placeholders}])", params
             else:  # operator == "$ltxtquery"
                 return (
-                    f"({effective_field_selector} @ :{param_name}::ltxtquery)",
+                    f"({effective_field_selector} @ CAST(:{param_name} AS ltxtquery))",
                     {param_name: filter_value},
                 )
         else:

--- a/tests/unit_tests/fixtures/metadata_filtering_data.py
+++ b/tests/unit_tests/fixtures/metadata_filtering_data.py
@@ -260,3 +260,49 @@ NEGATIVE_TEST_CASES = [
     {"$and": []},
     {"$not": True},
 ]
+
+LTREE_METADATAS = [
+    {"code": "DOC001", "category": "Top"},
+    {"code": "DOC002", "category": "Top.Science"},
+    {"code": "DOC003", "category": "Top.Science.Astronomy"},
+    {"code": "DOC004", "category": "Top.Technology"},
+    {"code": "DOC005", "category": "Top.Technology.AI"},
+]
+
+LTREE_FILTERING_TEST_CASES = [
+    # $ancestor: field @> value — field is ancestor-of-or-equal-to value
+    ({"category": {"$ancestor": "Top.Science"}}, ["DOC001", "DOC002"]),
+    (
+        {"category": {"$ancestor": "Top.Technology.AI"}},
+        ["DOC001", "DOC004", "DOC005"],
+    ),
+    # $descendant: field <@ value — field is descendant-of-or-equal-to value
+    ({"category": {"$descendant": "Top.Science"}}, ["DOC002", "DOC003"]),
+    (
+        {"category": {"$descendant": "Top"}},
+        ["DOC001", "DOC002", "DOC003", "DOC004", "DOC005"],
+    ),
+    # $lquery: field ~ pattern
+    ({"category": {"$lquery": "Top.*{1}"}}, ["DOC002", "DOC004"]),  # direct children
+    ({"category": {"$lquery": "Top.*{2}"}}, ["DOC003", "DOC005"]),  # grandchildren
+    ({"category": {"$lquery": "Top.Technology"}}, ["DOC004"]),  # exact match
+    # $lquery_any: field ? ARRAY[patterns]
+    (
+        {"category": {"$lquery_any": ["Top.Science", "Top.Technology"]}},
+        ["DOC002", "DOC004"],
+    ),
+    ({"category": {"$lquery_any": ["Top.*{2}"]}}, ["DOC003", "DOC005"]),
+    # $ltxtquery: field @ query — matches by label words
+    ({"category": {"$ltxtquery": "Science"}}, ["DOC002", "DOC003"]),
+    ({"category": {"$ltxtquery": "Technology"}}, ["DOC004", "DOC005"]),
+    ({"category": {"$ltxtquery": "AI"}}, ["DOC005"]),
+]
+
+LTREE_NEGATIVE_TEST_CASES = [
+    {"category": {"$ancestor": 42}},  # non-string value
+    {"category": {"$descendant": ["Top.Science"]}},  # non-string value
+    {"category": {"$lquery": True}},  # non-string value
+    {"category": {"$lquery_any": "Top.*"}},  # non-list value
+    {"category": {"$lquery_any": [123, "Top.*"]}},  # non-string item in list
+    {"category": {"$ltxtquery": 3.14}},  # non-string value
+]

--- a/tests/unit_tests/v2/test_pg_vectorstore_search.py
+++ b/tests/unit_tests/v2/test_pg_vectorstore_search.py
@@ -17,6 +17,9 @@ from langchain_postgres.v2.hybrid_search_config import (
 from langchain_postgres.v2.indexes import DistanceStrategy, HNSWQueryOptions
 from tests.unit_tests.fixtures.metadata_filtering_data import (
     FILTERING_TEST_CASES,
+    LTREE_FILTERING_TEST_CASES,
+    LTREE_METADATAS,
+    LTREE_NEGATIVE_TEST_CASES,
     METADATAS,
     NEGATIVE_TEST_CASES,
 )
@@ -33,6 +36,8 @@ CUSTOM_METADATA_JSON_TABLE = "custom_metadata_json" + str(uuid.uuid4()).replace(
 CUSTOM_METADATA_JSON_TABLE_SYNC = "custom_metadata_json_sync" + str(
     uuid.uuid4()
 ).replace("-", "_")
+LTREE_FILTER_TABLE = "ltree_filter" + str(uuid.uuid4()).replace("-", "_")
+LTREE_METADATA_JSON_TABLE = "ltree_json" + str(uuid.uuid4()).replace("-", "_")
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -52,6 +57,12 @@ filter_docs = [
 ]
 
 embeddings = [embeddings_service.embed_query("foo") for i in range(len(texts))]
+
+ltree_docs = [
+    Document(page_content=f"doc {i}", metadata=LTREE_METADATAS[i])
+    for i in range(len(LTREE_METADATAS))
+]
+ltree_ids = [str(uuid.uuid4()) for _ in range(len(LTREE_METADATAS))]
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -547,7 +558,7 @@ class TestVectorStoreSearchSync:
         self, vs_custom_filter_sync: PGVectorStore, test_filter: dict
     ) -> None:
         with pytest.raises((ValueError, NotImplementedError)):
-            docs = vs_custom_filter_sync.similarity_search(
+            vs_custom_filter_sync.similarity_search(
                 "meow", k=5, filter=test_filter
             )
 
@@ -574,3 +585,83 @@ class TestVectorStoreSearchSync:
             ),
         )
         assert results == [Document(page_content="foo", id=ids[0])]
+
+
+@pytest.mark.enable_socket
+@pytest.mark.asyncio(scope="class")
+class TestLtreeFiltering:
+    @pytest_asyncio.fixture(scope="class")
+    async def engine(self) -> AsyncIterator[PGEngine]:
+        engine = PGEngine.from_connection_string(url=CONNECTION_STRING)
+        yield engine
+        await aexecute(engine, f"DROP TABLE IF EXISTS {LTREE_FILTER_TABLE}")
+        await aexecute(engine, f"DROP TABLE IF EXISTS {LTREE_METADATA_JSON_TABLE}")
+        await engine.close()
+
+    @pytest_asyncio.fixture(scope="class")
+    async def vs_ltree(self, engine: PGEngine) -> AsyncIterator[PGVectorStore]:
+        await aexecute(engine, "CREATE EXTENSION IF NOT EXISTS ltree")
+        await engine.ainit_vectorstore_table(
+            LTREE_FILTER_TABLE,
+            VECTOR_SIZE,
+            metadata_columns=[Column("code", "TEXT"), Column("category", "ltree")],
+            id_column="langchain_id",
+            store_metadata=False,
+            overwrite_existing=True,
+        )
+        vs = await PGVectorStore.create(
+            engine,
+            embedding_service=embeddings_service,
+            table_name=LTREE_FILTER_TABLE,
+            metadata_columns=["code", "category"],
+            id_column="langchain_id",
+        )
+        await vs.aadd_documents(ltree_docs, ids=ltree_ids)
+        yield vs
+
+    @pytest_asyncio.fixture(scope="class")
+    async def vs_ltree_json(self, engine: PGEngine) -> AsyncIterator[PGVectorStore]:
+        """Tests the (json_col->>'field')::ltree cast path."""
+        await aexecute(engine, "CREATE EXTENSION IF NOT EXISTS ltree")
+        await engine.ainit_vectorstore_table(
+            LTREE_METADATA_JSON_TABLE,
+            VECTOR_SIZE,
+            store_metadata=True,
+            overwrite_existing=True,
+        )
+        vs = await PGVectorStore.create(
+            engine,
+            embedding_service=embeddings_service,
+            table_name=LTREE_METADATA_JSON_TABLE,
+        )
+        await vs.aadd_documents(ltree_docs, ids=ltree_ids)
+        yield vs
+
+    @pytest.mark.parametrize("test_filter, expected_codes", LTREE_FILTERING_TEST_CASES)
+    async def test_ltree_dedicated_column(
+        self,
+        vs_ltree: PGVectorStore,
+        test_filter: dict,
+        expected_codes: list[str],
+    ) -> None:
+        docs = await vs_ltree.asimilarity_search("doc", k=10, filter=test_filter)
+        assert sorted(doc.metadata["code"] for doc in docs) == sorted(expected_codes)
+
+    @pytest.mark.parametrize("test_filter, expected_codes", LTREE_FILTERING_TEST_CASES)
+    async def test_ltree_json_metadata(
+        self,
+        vs_ltree_json: PGVectorStore,
+        test_filter: dict,
+        expected_codes: list[str],
+    ) -> None:
+        docs = await vs_ltree_json.asimilarity_search("doc", k=10, filter=test_filter)
+        assert sorted(doc.metadata["code"] for doc in docs) == sorted(expected_codes)
+
+    @pytest.mark.parametrize("test_filter", LTREE_NEGATIVE_TEST_CASES)
+    async def test_ltree_negative(
+        self,
+        vs_ltree: PGVectorStore,
+        test_filter: dict,
+    ) -> None:
+        with pytest.raises((ValueError, NotImplementedError)):
+            await vs_ltree.asimilarity_search("doc", k=10, filter=test_filter)


### PR DESCRIPTION
Adds 5 PostgreSQL \`ltree\` operator filters to the v2 vector store metadata filtering system.

## Summary

Extends the MongoDB-style filter system with operators that map directly to PostgreSQL's built-in [\`ltree\`](https://www.postgresql.org/docs/current/ltree.html) extension, enabling hierarchical path queries over tree-structured label data such as category taxonomies, org charts, and file paths.

## Motivation

In many retrieval system, a typical tree document system is implemented for order of files.
The existing filter system has no way to query \`ltree\`-typed columns or hierarchical path data stored in the JSON metadata column. Applications that classify documents with paths like \`Top.Science.Astronomy\` need ancestor/descendant traversal and pattern-matching that the \`ltree\` extension provides natively — none of which is expressible with \`\$eq\`, \`\$like\`, or the other existing operators.

## Changes

- **\`langchain_postgres/v2/async_vectorstore.py\`**: Added \`LTREE_OPERATORS\` constant, extended \`SUPPORTED_OPERATORS\`, and implemented the \`elif operator in LTREE_OPERATORS\` branch in \`_handle_field_filter\` with per-operator input validation and SQL generation
- **\`tests/unit_tests/fixtures/metadata_filtering_data.py\`**: Added \`LTREE_METADATAS\`, \`LTREE_FILTERING_TEST_CASES\` (12 cases), and \`LTREE_NEGATIVE_TEST_CASES\` (6 cases)
- **\`tests/unit_tests/v2/test_pg_vectorstore_search.py\`**: Added \`TestLtreeFiltering\` class with fixtures for both storage modes and 30 parametrized tests

## New Operators

| Operator | PostgreSQL | Description |
|---|---|---|
| \`\$ancestor\` | \`field @> CAST(val AS ltree)\` | Field is an ancestor of (or equal to) the value |
| \`\$descendant\` | \`field <@ CAST(val AS ltree)\` | Field is a descendant of (or equal to) the value |
| \`\$lquery\` | \`field ~ CAST(val AS lquery)\` | Field matches an lquery wildcard pattern |
| \`\$lquery_any\` | \`field ? ARRAY[...]\` | Field matches any pattern in a list of lqueries |
| \`\$ltxtquery\` | \`field @ CAST(val AS ltxtquery)\` | Field matches an ltxtquery full-text expression |

## Usage Examples

\`\`\`python
# \$ancestor — find categories that are on the path UP TO "Top.Science.Astronomy"
# ("Top" and "Top.Science" are ancestors of "Top.Science.Astronomy")
results = await vs.asimilarity_search(
    "query", filter={"category": {"\$ancestor": "Top.Science.Astronomy"}}
)

# \$descendant — find all documents under "Top.Science" (inclusive)
results = await vs.asimilarity_search(
    "query", filter={"category": {"\$descendant": "Top.Science"}}
)

# \$lquery — match direct children of Top only
results = await vs.asimilarity_search(
    "query", filter={"category": {"\$lquery": "Top.*{1}"}}
)

# \$lquery_any — match either of two exact paths
results = await vs.asimilarity_search(
    "query", filter={"category": {"\$lquery_any": ["Top.Science", "Top.Technology"]}}
)

# \$ltxtquery — match any path containing the label word "Science"
results = await vs.asimilarity_search(
    "query", filter={"category": {"\$ltxtquery": "Science"}}
)
\`\`\`

## Implementation Details

- Works with both **dedicated \`ltree\` columns** and **JSON-stored metadata** (the \`langchain_metadata\` JSONB column). For JSON fields, the \`->>\` extracted text is automatically cast to \`ltree\` before the operator is applied.
- Uses \`CAST(:param AS type)\` parameter syntax rather than \`:param::type\` to avoid a psycopg3 driver issue where \`::\` immediately following a named placeholder prevents parameter substitution.
- Requires the \`ltree\` PostgreSQL extension. The test fixtures call \`CREATE EXTENSION IF NOT EXISTS ltree\`; the pgvector Docker image ships with it pre-installed.

## Test Coverage

- 12 positive test cases × 2 storage modes (dedicated \`ltree\` column + JSON metadata) = 24 passing tests
- 6 negative tests confirming that wrong value types raise \`ValueError\`
- All 44 existing metadata filter tests continue to pass — no regressions

## Breaking Changes

None — fully backward compatible.

## Checklist

- [x] Tests added and passing (30 new + 44 regression)
- [x] Type hints correct (\`mypy\` clean)
- [x] Linting passes (\`ruff check\`, \`ruff format\`)
- [x] Spelling check passes (\`codespell\`)
- [x] No breaking changes