### PR TITLE
fix: add IF NOT EXISTS to CREATE TABLE query

### DIFF
--- a/langchain_postgres/v2/engine.py
+++ b/langchain_postgres/v2/engine.py
@@ -243,7 +243,7 @@ class PGEngine:
             hybrid_search_config.tsv_column = hybrid_search_column_name
             hybrid_search_column = f',"{self._escape_postgres_identifier(hybrid_search_column_name)}" TSVECTOR NOT NULL'
 
-        query = f"""CREATE TABLE "{schema_name}"."{table_name}"(
+        query = f"""CREATE TABLE IF NOT EXISTS "{schema_name}"."{table_name}"(
             "{id_column_name}" {id_data_type} PRIMARY KEY,
             "{content_column}" TEXT NOT NULL,
             "{embedding_column}" vector({vector_size}) NOT NULL


### PR DESCRIPTION
Adds IF NOT EXISTS to the CREATE TABLE query in `_ainit_vectorstore_table` to prevent errors when the table already exists.