### PR TITLE
feat: add multi-host HA connection support for PostgreSQL clusters

### DIFF
--- a/langchain_postgres/v2/engine.py
+++ b/langchain_postgres/v2/engine.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from threading import Thread
-from typing import Any, Awaitable, Optional, TypedDict, TypeVar, Union
+from typing import Any, Awaitable, Literal, Optional, TypedDict, TypeVar, Union
+from urllib.parse import quote_plus
 
 from sqlalchemy import text
 from sqlalchemy.engine import URL
@@ -12,6 +13,15 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from .hybrid_search_config import HybridSearchConfig
 
 T = TypeVar("T")
+
+TargetSessionAttrs = Literal[
+    "any",
+    "read-write",
+    "read-only",
+    "primary",
+    "standby",
+    "prefer-standby",
+]
 
 
 class ColumnDict(TypedDict):
@@ -68,7 +78,7 @@ class PGEngine:
 
         if key != PGEngine.__create_key:
             raise Exception(
-                "Only create class through 'from_connection_string' or 'from_engine' methods!"
+                "Only create class through 'from_connection_string', 'from_engine', or 'from_hosts' methods!"
             )
         self._pool = pool
         self._loop = loop
@@ -111,6 +121,126 @@ class PGEngine:
 
         engine = create_async_engine(url, **kwargs)
         return cls(cls.__create_key, engine, cls._default_loop, cls._default_thread)
+
+    @staticmethod
+    def _build_multi_host_connection_string(
+        hosts: list[str],
+        user: str,
+        password: str,
+        database: str,
+        ports: Optional[list[int]] = None,
+        target_session_attrs: TargetSessionAttrs = "any",
+    ) -> str:
+        """Build a multi-host psycopg connection string for HA PostgreSQL clusters.
+
+        Args:
+            hosts: List of PostgreSQL host addresses.
+            user: Database user name.
+            password: Database password.
+            database: Database name.
+            ports: List of ports corresponding to each host.
+                If a single-element list is provided, that port is used for all hosts.
+                Defaults to [5432] for all hosts.
+            target_session_attrs: Session attribute requirement for connection routing.
+                Defaults to "any".
+
+        Returns:
+            A SQLAlchemy-compatible connection string with postgresql+psycopg:// scheme.
+
+        Raises:
+            ValueError: If hosts is empty, any host is empty, or ports length is invalid.
+        """
+        if not hosts:
+            raise ValueError("At least one host must be specified.")
+        for h in hosts:
+            if not h or not h.strip():
+                raise ValueError("Host strings must not be empty.")
+            if "," in h:
+                raise ValueError(f"Host cannot contain comma: {h}")
+
+        if ports is None:
+            ports = [5432] * len(hosts)
+        elif len(ports) == 1:
+            ports = ports * len(hosts)
+        elif len(ports) != len(hosts):
+            raise ValueError(
+                f"Length of ports ({len(ports)}) must match length of hosts "
+                f"({len(hosts)}) or be a single port."
+            )
+        for p in ports:
+            if not isinstance(p, int) or p <= 0 or p > 65535:
+                raise ValueError(
+                    f"Port must be a positive integer between 1 and 65535, got {p}."
+                )
+
+        host_param = ",".join(h.strip() for h in hosts)
+        port_param = ",".join(str(p) for p in ports)
+
+        url = (
+            f"postgresql+psycopg://{quote_plus(user)}:{quote_plus(password)}"
+            f"@/{quote_plus(database)}"
+            f"?host={host_param}&port={port_param}"
+            f"&target_session_attrs={target_session_attrs}"
+        )
+        return url
+
+    @classmethod
+    def from_hosts(
+        cls,
+        hosts: list[str],
+        user: str,
+        password: str,
+        database: str,
+        ports: Optional[list[int]] = None,
+        target_session_attrs: TargetSessionAttrs = "any",
+        **kwargs: Any,
+    ) -> PGEngine:
+        """Create a PGEngine instance for HA PostgreSQL clusters with multiple hosts.
+
+        Uses psycopg3's native multi-host support with target_session_attrs for
+        connection routing (e.g., always connect to primary, prefer standby, etc.).
+
+        Args:
+            hosts: List of PostgreSQL host addresses.
+            user: Database user name.
+            password: Database password.
+            database: Database name.
+            ports: List of ports corresponding to each host.
+                If a single-element list, that port is used for all hosts.
+                Defaults to [5432] for all hosts.
+            target_session_attrs: Session attribute requirement for connection routing.
+                Options: "any", "read-write", "read-only", "primary", "standby",
+                "prefer-standby". Defaults to "any".
+            **kwargs: Additional keyword arguments passed to SQLAlchemy's
+                create_async_engine (e.g., pool_size, max_overflow, echo).
+
+        Returns:
+            PGEngine
+
+        Raises:
+            ValueError: If hosts is empty or ports/hosts length mismatch.
+
+        Example::
+
+            engine = PGEngine.from_hosts(
+                hosts=["primary.db.example.com", "replica1.db.example.com"],
+                user="myuser",
+                password="mypassword",
+                database="mydb",
+                ports=[5432, 5432],
+                target_session_attrs="primary",
+                pool_size=5,
+            )
+        """
+        url = cls._build_multi_host_connection_string(
+            hosts=hosts,
+            user=user,
+            password=password,
+            database=database,
+            ports=ports,
+            target_session_attrs=target_session_attrs,
+        )
+        return cls.from_connection_string(url=url, **kwargs)
 
     async def _run_as_async(self, coro: Awaitable[T]) -> T:
         """Run an async coroutine asynchronously"""

--- a/tests/unit_tests/v2/test_engine.py
+++ b/tests/unit_tests/v2/test_engine.py
@@ -12,7 +12,16 @@ from sqlalchemy.pool import NullPool
 
 from langchain_postgres import Column, PGEngine
 from langchain_postgres.v2.hybrid_search_config import HybridSearchConfig
-from tests.utils import VECTORSTORE_CONNECTION_STRING as CONNECTION_STRING
+from tests.utils import (
+    POSTGRES_DB,
+    POSTGRES_HOST,
+    POSTGRES_PASSWORD,
+    POSTGRES_PORT,
+    POSTGRES_USER,
+)
+from tests.utils import (
+    VECTORSTORE_CONNECTION_STRING as CONNECTION_STRING,
+)
 
 DEFAULT_TABLE = "default" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "custom" + str(uuid.uuid4()).replace("-", "_")
@@ -24,6 +33,7 @@ CUSTOM_TABLE_SYNC = "custom_sync" + str(uuid.uuid4()).replace("-", "_")
 HYBRID_SEARCH_TABLE_SYNC = "hybrid_sync" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TYPEDDICT_TABLE_SYNC = "custom_td_sync" + str(uuid.uuid4()).replace("-", "_")
 INT_ID_CUSTOM_TABLE_SYNC = "custom_int_id_sync" + str(uuid.uuid4()).replace("-", "_")
+MULTI_HOST_TABLE = "multi_host" + str(uuid.uuid4()).replace("-", "_")
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -410,3 +420,185 @@ class TestEngineSync:
         key = object()
         with pytest.raises(Exception):
             PGEngine(key, engine._pool, None, None)
+
+
+class TestBuildMultiHostConnectionString:
+    """Unit tests for multi-host connection string building."""
+
+    def test_basic_two_hosts(self) -> None:
+        url = PGEngine._build_multi_host_connection_string(
+            hosts=["host1", "host2"],
+            user="myuser",
+            password="mypass",
+            database="mydb",
+            ports=[5432, 5433],
+            target_session_attrs="primary",
+        )
+        assert "postgresql+psycopg://" in url
+        assert "host=host1,host2" in url
+        assert "port=5432,5433" in url
+        assert "target_session_attrs=primary" in url
+        assert "myuser" in url
+        assert "/mydb" in url
+
+    def test_single_port_broadcast(self) -> None:
+        url = PGEngine._build_multi_host_connection_string(
+            hosts=["h1", "h2", "h3"],
+            user="u",
+            password="p",
+            database="db",
+            ports=[5432],
+        )
+        assert "port=5432,5432,5432" in url
+
+    def test_default_ports(self) -> None:
+        url = PGEngine._build_multi_host_connection_string(
+            hosts=["h1", "h2"],
+            user="u",
+            password="p",
+            database="db",
+        )
+        assert "port=5432,5432" in url
+
+    def test_default_target_session_attrs(self) -> None:
+        url = PGEngine._build_multi_host_connection_string(
+            hosts=["h1"],
+            user="u",
+            password="p",
+            database="db",
+        )
+        assert "target_session_attrs=any" in url
+
+    def test_special_characters_in_password(self) -> None:
+        url = PGEngine._build_multi_host_connection_string(
+            hosts=["h1"],
+            user="user",
+            password="p@ss:word/special",
+            database="db",
+        )
+        assert "p%40ss" in url
+
+    def test_empty_hosts_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least one host"):
+            PGEngine._build_multi_host_connection_string(
+                hosts=[],
+                user="u",
+                password="p",
+                database="db",
+            )
+
+    def test_empty_host_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            PGEngine._build_multi_host_connection_string(
+                hosts=["h1", ""],
+                user="u",
+                password="p",
+                database="db",
+            )
+
+    def test_host_with_comma_raises(self) -> None:
+        with pytest.raises(ValueError, match="cannot contain comma"):
+            PGEngine._build_multi_host_connection_string(
+                hosts=["host1,host2"],
+                user="u",
+                password="p",
+                database="db",
+            )
+
+    def test_whitespace_in_hosts_stripped(self) -> None:
+        url = PGEngine._build_multi_host_connection_string(
+            hosts=["  host1  ", " host2"],
+            user="u",
+            password="p",
+            database="db",
+        )
+        assert "host=host1,host2" in url
+
+    def test_ports_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="must match length of hosts"):
+            PGEngine._build_multi_host_connection_string(
+                hosts=["h1", "h2", "h3"],
+                user="u",
+                password="p",
+                database="db",
+                ports=[5432, 5433],
+            )
+
+    def test_invalid_port_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="positive integer"):
+            PGEngine._build_multi_host_connection_string(
+                hosts=["h1"],
+                user="u",
+                password="p",
+                database="db",
+                ports=[0],
+            )
+
+    def test_port_out_of_range_raises(self) -> None:
+        with pytest.raises(ValueError, match="positive integer"):
+            PGEngine._build_multi_host_connection_string(
+                hosts=["h1"],
+                user="u",
+                password="p",
+                database="db",
+                ports=[99999],
+            )
+
+    def test_all_target_session_attrs_values(self) -> None:
+        for attr in [
+            "any",
+            "read-write",
+            "read-only",
+            "primary",
+            "standby",
+            "prefer-standby",
+        ]:
+            url = PGEngine._build_multi_host_connection_string(
+                hosts=["h1"],
+                user="u",
+                password="p",
+                database="db",
+                target_session_attrs=attr,  # type: ignore[arg-type]
+            )
+            assert f"target_session_attrs={attr}" in url
+
+
+@pytest.mark.enable_socket
+@pytest.mark.asyncio
+class TestEngineMultiHost:
+    @pytest_asyncio.fixture(scope="class")
+    async def engine(self) -> AsyncIterator[PGEngine]:
+        engine = PGEngine.from_hosts(
+            hosts=[POSTGRES_HOST],
+            user=POSTGRES_USER,
+            password=POSTGRES_PASSWORD,
+            database=POSTGRES_DB,
+            ports=[int(POSTGRES_PORT)],
+            target_session_attrs="any",
+        )
+        yield engine
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{MULTI_HOST_TABLE}"')
+        await engine.close()
+
+    async def test_from_hosts_single_host(self, engine: PGEngine) -> None:
+        await aexecute(engine, "SELECT 1")
+
+    async def test_from_hosts_creates_table(self, engine: PGEngine) -> None:
+        await engine.ainit_vectorstore_table(MULTI_HOST_TABLE, VECTOR_SIZE)
+        stmt = f"SELECT column_name FROM information_schema.columns WHERE table_name = '{MULTI_HOST_TABLE}';"
+        results = await afetch(engine, stmt)
+        assert len(results) > 0
+
+    async def test_from_hosts_with_engine_kwargs(self) -> None:
+        engine = PGEngine.from_hosts(
+            hosts=[POSTGRES_HOST],
+            user=POSTGRES_USER,
+            password=POSTGRES_PASSWORD,
+            database=POSTGRES_DB,
+            ports=[int(POSTGRES_PORT)],
+            target_session_attrs="any",
+            pool_size=3,
+            max_overflow=2,
+        )
+        assert "Pool size: 3" in engine._pool.pool.status()
+        await engine.close()


### PR DESCRIPTION
## Description

Add `PGEngine.from_hosts()` factory method that enables connections to high-availability PostgreSQL clusters with automatic failover, using psycopg3's native multi-host connection support.

## Motivation

Production PostgreSQL deployments commonly use primary/replica topologies (e.g., Patroni, Citus, streaming replication) where clients need to connect to multiple hosts with automatic failover. Currently, `PGEngine` only supports single-host connection strings via `from_connection_string()` or `from_engine()`. This PR adds first-class support for multi-host HA connections with `target_session_attrs` routing, enabling users to direct queries to primaries, standbys, or any available node.

## Changes

- New `from_hosts()` classmethod on `PGEngine` accepting multiple host addresses, per-host ports, and `target_session_attrs` for connection routing
- New `_build_multi_host_connection_string()` static method that constructs psycopg3-compatible multi-host connection URLs
- `TargetSessionAttrs` Literal type for valid routing options (`any`, `read-write`, `read-only`, `primary`, `standby`, `prefer-standby`)
- Input validation for empty hosts, port ranges (1-65535), host/port length mismatches, and comma-in-host injection
- URL encoding of user, password, and database via `urllib.parse.quote_plus`
- Single-port broadcast (one port applied to all hosts) and default port (5432) support
- Comprehensive unit tests for connection string building (validation, edge cases, all routing options)
- Integration tests for `from_hosts()` with table creation and engine kwargs passthrough

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [x] Tests added and passing
- [x] No breaking changes

## Example Usage

### Connecting to an HA PostgreSQL cluster (primary + replicas)

```python
from langchain_postgres import PGEngine, PGVectorStore
from langchain_core.embeddings import DeterministicFakeEmbedding

# HA cluster with 1 primary + 2 replicas (e.g., Patroni, Citus, streaming replication)
engine = PGEngine.from_hosts(
    hosts=[
        "pg-node1.example.com",
        "pg-node2.example.com",
        "pg-node3.example.com",
    ],
    user="app_user",
    password="secret",
    database="vectordb",
    ports=[5432],  # Same port for all nodes
    target_session_attrs="primary",  # Always route to the current primary
    pool_size=5,
    max_overflow=2,
)

# Use the engine as usual — failover is handled automatically by psycopg3
embedding = DeterministicFakeEmbedding(size=768)
engine.init_vectorstore_table("my_docs", vector_size=768)

store = PGVectorStore.create_sync(
    engine=engine,
    table_name="my_docs",
    embedding_service=embedding,
)

store.add_documents([...])