### PR TITLE
fix: order-dependent tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ test = [
     "pytest-asyncio>=0.25.3",
     "pytest-cov>=6.0.0",
     "pytest-mock>=3.14.0",
+    "pytest-randomly>=4.1.0",
     "pytest-socket>=0.7.0",
     "pytest-timeout>=2.3.1",
     "pytest-watcher>=0.4.3",

--- a/tests/unit_tests/v2/test_async_pg_vectorstore.py
+++ b/tests/unit_tests/v2/test_async_pg_vectorstore.py
@@ -440,7 +440,7 @@ class TestVectorStore:
         assert "foo" not in content
         await aexecute(engine, f'TRUNCATE TABLE "{CUSTOM_TABLE}"')
 
-    async def test_ignore_metadata_columns(self, engine: PGEngine) -> None:
+    async def test_ignore_metadata_columns(self, engine: PGEngine, vs_custom: AsyncPGVectorStore) -> None:
         column_to_ignore = "source"
         vs = await AsyncPGVectorStore.create(
             engine,

--- a/tests/unit_tests/v2/test_async_pg_vectorstore_search.py
+++ b/tests/unit_tests/v2/test_async_pg_vectorstore_search.py
@@ -285,7 +285,7 @@ class TestVectorStoreSearch:
         assert len(results) == 1
 
     async def test_similarity_search_with_relevance_scores_threshold_euclidean(
-        self, engine: PGEngine
+        self, engine: PGEngine, vs: AsyncPGVectorStore
     ) -> None:
         vs = await AsyncPGVectorStore.create(
             engine,

--- a/tests/unit_tests/v2/test_pg_vectorstore_index.py
+++ b/tests/unit_tests/v2/test_pg_vectorstore_index.py
@@ -104,6 +104,7 @@ class TestIndex:
         assert not result
 
     async def test_aapply_vector_index_ivfflat(self, vs: PGVectorStore) -> None:
+        vs.drop_vector_index(DEFAULT_INDEX_NAME)
         index = IVFFlatIndex(
             name=DEFAULT_INDEX_NAME, distance_strategy=DistanceStrategy.EUCLIDEAN
         )
@@ -221,6 +222,7 @@ class TestAsyncIndex:
         assert not result
 
     async def test_aapply_vector_index_ivfflat(self, vs: PGVectorStore) -> None:
+        await vs.adrop_vector_index(DEFAULT_INDEX_NAME_ASYNC)
         index = IVFFlatIndex(
             name=DEFAULT_INDEX_NAME_ASYNC, distance_strategy=DistanceStrategy.EUCLIDEAN
         )

--- a/tests/unit_tests/v2/test_pg_vectorstore_search.py
+++ b/tests/unit_tests/v2/test_pg_vectorstore_search.py
@@ -227,7 +227,7 @@ class TestVectorStoreSearch:
         assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_similarity_search_with_relevance_scores_threshold_euclidean(
-        self, engine: PGEngine
+        self, engine: PGEngine, vs: PGVectorStore
     ) -> None:
         vs = await PGVectorStore.create(
             engine,

--- a/uv.lock
+++ b/uv.lock
@@ -581,6 +581,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-randomly" },
     { name = "pytest-socket" },
     { name = "pytest-timeout" },
     { name = "pytest-watcher" },
@@ -608,6 +609,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
@@ -1304,6 +1306,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix test isolation issues introduced by `pytest-randomly`. Some of the tests could not run independently without relying on sibling tests, which breaks tests isolation.