### PR TITLE
fix(v2): don't mutate instance hybrid_search_config in similarity searches

### DIFF
--- a/langchain_postgres/v2/async_vectorstore.py
+++ b/langchain_postgres/v2/async_vectorstore.py
@@ -782,6 +782,10 @@ class AsyncPGVectorStore(VectorStore):
             "hybrid_search_config", self.hybrid_search_config
         )
         if hybrid_search_config and not hybrid_search_config.fts_query:
+            # Avoid mutating the caller-provided / instance config object —
+            # setting `fts_query` on the shared instance variable would leak
+            # the first query into every subsequent search.
+            hybrid_search_config = copy.copy(hybrid_search_config)
             hybrid_search_config.fts_query = query
             kwargs["hybrid_search_config"] = hybrid_search_config
 
@@ -821,6 +825,10 @@ class AsyncPGVectorStore(VectorStore):
             "hybrid_search_config", self.hybrid_search_config
         )
         if hybrid_search_config and not hybrid_search_config.fts_query:
+            # Avoid mutating the caller-provided / instance config object —
+            # setting `fts_query` on the shared instance variable would leak
+            # the first query into every subsequent search.
+            hybrid_search_config = copy.copy(hybrid_search_config)
             hybrid_search_config.fts_query = query
             kwargs["hybrid_search_config"] = hybrid_search_config
 

--- a/tests/unit_tests/v2/test_async_vectorstore_no_mutation.py
+++ b/tests/unit_tests/v2/test_async_vectorstore_no_mutation.py
@@ -1,0 +1,108 @@
+"""Regression tests pinning that `AsyncPGVectorStore.asimilarity_search*`
+methods do not mutate the instance/caller-provided `hybrid_search_config`.
+
+Without copying the config before back-filling `fts_query`, the very first
+search query "sticks" on the shared `HybridSearchConfig` object and every
+later call reuses it. Verified against #288.
+
+These tests bypass `AsyncPGVectorStore.create(...)` (which needs a real
+Postgres engine) by stubbing the few attributes the relevant methods touch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from langchain_postgres.v2.async_vectorstore import AsyncPGVectorStore
+from langchain_postgres.v2.hybrid_search_config import HybridSearchConfig
+
+
+@dataclass
+class _FakeEmbeddingService:
+    """Minimal async embedder — emits a fixed dummy vector per call."""
+
+    vector: list[float]
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return list(self.vector)
+
+
+def _make_store(hybrid_config: HybridSearchConfig) -> AsyncPGVectorStore:
+    """Build a barebones `AsyncPGVectorStore` without touching the DB."""
+    store = object.__new__(AsyncPGVectorStore)
+    store.embedding_service = _FakeEmbeddingService(vector=[0.1, 0.2, 0.3])
+    store.hybrid_search_config = hybrid_config
+    store.asimilarity_search_by_vector = AsyncMock(return_value=[])
+    store.asimilarity_search_with_score_by_vector = AsyncMock(return_value=[])
+    return store
+
+
+@pytest.mark.asyncio
+async def test_asimilarity_search_does_not_mutate_instance_hybrid_search_config() -> (
+    None
+):
+    """First call's `query` must not leak into the instance config's
+    `fts_query`, so subsequent searches with different queries see their
+    own values."""
+    config = HybridSearchConfig(fts_query="")
+    store = _make_store(config)
+
+    await store.asimilarity_search("first query")
+    await store.asimilarity_search("second query")
+
+    # Instance-level config still has its original empty fts_query.
+    assert config.fts_query == ""
+    # And each downstream call got its own config copy with the right query.
+    calls = store.asimilarity_search_by_vector.await_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["hybrid_search_config"].fts_query == "first query"
+    assert calls[1].kwargs["hybrid_search_config"].fts_query == "second query"
+    # The instance config object is not the one passed downstream.
+    assert calls[0].kwargs["hybrid_search_config"] is not config
+
+
+@pytest.mark.asyncio
+async def test_asimilarity_search_with_score_does_not_mutate_instance_config() -> None:
+    """Same invariant for `asimilarity_search_with_score`, which has the
+    same back-fill block."""
+    config = HybridSearchConfig(fts_query="")
+    store = _make_store(config)
+
+    await store.asimilarity_search_with_score("first query")
+    await store.asimilarity_search_with_score("second query")
+
+    assert config.fts_query == ""
+    calls = store.asimilarity_search_with_score_by_vector.await_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["hybrid_search_config"].fts_query == "first query"
+    assert calls[1].kwargs["hybrid_search_config"].fts_query == "second query"
+
+
+@pytest.mark.asyncio
+async def test_asimilarity_search_does_not_mutate_caller_provided_config() -> None:
+    """A `HybridSearchConfig` passed via kwargs should also be left alone —
+    callers may reuse the same object across calls."""
+    caller_config = HybridSearchConfig(fts_query="")
+    store = _make_store(HybridSearchConfig(fts_query=""))
+
+    await store.asimilarity_search("query A", hybrid_search_config=caller_config)
+    await store.asimilarity_search("query B", hybrid_search_config=caller_config)
+
+    assert caller_config.fts_query == ""
+
+
+@pytest.mark.asyncio
+async def test_asimilarity_search_preserves_existing_fts_query() -> None:
+    """If the caller already set `fts_query`, the method must leave it
+    alone (the back-fill branch only fires when `fts_query` is empty)."""
+    caller_config = HybridSearchConfig(fts_query="user-specified")
+    store = _make_store(HybridSearchConfig(fts_query=""))
+
+    await store.asimilarity_search("ignored", hybrid_search_config=caller_config)
+
+    calls: list[Any] = store.asimilarity_search_by_vector.await_args_list
+    assert calls[0].kwargs["hybrid_search_config"].fts_query == "user-specified"


### PR DESCRIPTION
## Description

\`AsyncPGVectorStore.asimilarity_search\` and \`asimilarity_search_with_score\` back-fill \`fts_query\` on the \`HybridSearchConfig\` object retrieved from kwargs or, by default, from \`self.hybrid_search_config\`:

\`\`\`python
hybrid_search_config = kwargs.get(\"hybrid_search_config\", self.hybrid_search_config)
if hybrid_search_config and not hybrid_search_config.fts_query:
    hybrid_search_config.fts_query = query  # ← in-place
    kwargs[\"hybrid_search_config\"] = hybrid_search_config
\`\`\`

Because the assignment hits the shared object in place, the very first call's \`query\` sticks on it and every subsequent search reuses that \`fts_query\` regardless of the new \`query\` argument. Same hazard for callers that pass the same \`HybridSearchConfig\` to multiple searches. This is exactly the symptom reported in #288.

The fix is to copy the config before back-filling, mirroring how other LangChain integrations handle caller-owned input (see e.g. langchain-anthropic's recent \`bind_tools\` mutation fix).

## Relevant issues

Fixes #288

## Changes

- \`langchain_postgres/v2/async_vectorstore.py\`: in both \`asimilarity_search\` and \`asimilarity_search_with_score\`, \`copy.copy(hybrid_search_config)\` before assigning \`fts_query\`. The \`copy\` module is already imported at the top of the file.
- \`tests/unit_tests/v2/test_async_vectorstore_no_mutation.py\`: four async unit tests that bypass \`AsyncPGVectorStore.create(...)\` (no Postgres needed) and pin:
  - instance-level config is preserved across two calls;
  - caller-provided config is preserved when reused across calls;
  - existing \`fts_query\` is not overwritten (back-fill branch correctly skips);
  - \`asimilarity_search_with_score\` has the same invariants.

## Testing

\`\`\`
$ python -m pytest tests/unit_tests/v2/test_async_vectorstore_no_mutation.py -q
4 passed in 0.49s
\`\`\`

Reverting only the \`copy.copy(...)\` line while keeping the new tests makes three of the four tests fail (the fourth covers the no-back-fill branch and is unaffected), confirming the regression coverage pins the buggy behavior. \`ruff check\` and \`ruff format --check\` pass on both files.

## Note

Fix is intentionally minimal — a shallow \`copy.copy\` is sufficient because \`HybridSearchConfig\` is a flat dataclass and only \`fts_query\` (a string) is reassigned. No callers need updating; non-hybrid-search paths are untouched.

_Disclaimer: this PR was prepared with the assistance of an AI agent (Claude Code). All code and test changes were reviewed by the author before submission._