### PR TITLE
fix: defer `PostgresChatMessageHistory` import to keep psycopg lazy

### DIFF
--- a/langchain_postgres/__init__.py
+++ b/langchain_postgres/__init__.py
@@ -1,16 +1,43 @@
 from importlib import metadata
+from typing import TYPE_CHECKING, Any
 
-from langchain_postgres.chat_message_histories import PostgresChatMessageHistory
 from langchain_postgres.translator import PGVectorTranslator
 from langchain_postgres.v2.engine import Column, ColumnDict, PGEngine
 from langchain_postgres.v2.vectorstores import PGVectorStore
 from langchain_postgres.vectorstores import PGVector
+
+if TYPE_CHECKING:
+    from langchain_postgres.chat_message_histories import (
+        PostgresChatMessageHistory,
+    )
 
 try:
     __version__ = metadata.version(__package__)
 except metadata.PackageNotFoundError:
     # Case where package metadata is not available.
     __version__ = ""
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import optional symbols that pull in heavyweight or
+    LGPL-licensed transitive dependencies (e.g. `psycopg`).
+
+    Importing `PostgresChatMessageHistory` from this package triggers
+    `import psycopg`, which is LGPL-3.0 and may be undesirable for
+    downstreams that only use the driver-agnostic v2 API (`PGEngine`,
+    `PGVectorStore`, ...). Deferring the import until the symbol is
+    actually accessed keeps `from langchain_postgres import PGEngine`
+    (and similar) free of any psycopg load.
+    """
+    if name == "PostgresChatMessageHistory":
+        from langchain_postgres.chat_message_histories import (
+            PostgresChatMessageHistory,
+        )
+
+        return PostgresChatMessageHistory
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
 
 __all__ = [
     "__version__",

--- a/tests/unit_tests/test_lazy_chat_message_histories.py
+++ b/tests/unit_tests/test_lazy_chat_message_histories.py
@@ -1,0 +1,90 @@
+"""Regression tests for the lazy import of `PostgresChatMessageHistory`.
+
+`langchain_postgres/__init__.py` used to eagerly import
+`chat_message_histories.PostgresChatMessageHistory`, which top-level-imports
+`psycopg`. That meant `from langchain_postgres import PGEngine` (or any
+other driver-agnostic v2 symbol) transitively loaded the LGPL-licensed
+`psycopg`, breaking downstreams that ship only the v2 API on a non-LGPL
+PostgreSQL driver such as `asyncpg`. See #296.
+
+These tests assert:
+
+- accessing `PostgresChatMessageHistory` via package attribute lookup still
+  works (no backward-compat regression);
+- a fresh subprocess that only imports `langchain_postgres` does **not**
+  transitively load `psycopg`;
+- the same subprocess gains a `psycopg` import once the lazy attribute is
+  actually touched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_postgres_chat_message_history_accessible_via_package() -> None:
+    import langchain_postgres
+    from langchain_postgres.chat_message_histories import (
+        PostgresChatMessageHistory as _Direct,
+    )
+
+    assert langchain_postgres.PostgresChatMessageHistory is _Direct
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    import langchain_postgres
+
+    try:
+        _ = langchain_postgres.DefinitelyDoesNotExist  # type: ignore[attr-defined]
+    except AttributeError as exc:
+        assert "DefinitelyDoesNotExist" in str(exc)
+    else:  # pragma: no cover
+        msg = "Expected AttributeError"
+        raise AssertionError(msg)
+
+
+def _run_python(snippet: str) -> str:
+    """Run `snippet` in a fresh subprocess and return its stdout (one line)."""
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    return result.stdout.strip()
+
+
+def test_psycopg_not_imported_when_only_v2_symbols_used() -> None:
+    """`from langchain_postgres import PGEngine, PGVectorStore` must NOT
+    transitively load `psycopg`."""
+    out = _run_python(
+        """
+        import sys
+        from langchain_postgres import PGEngine, PGVectorStore  # noqa: F401
+        print("psycopg" in sys.modules)
+        """
+    )
+    assert out == "False", (
+        f"psycopg should not be imported eagerly; got sys.modules check={out!r}"
+    )
+
+
+def test_psycopg_is_imported_when_lazy_symbol_is_accessed() -> None:
+    """Accessing the lazy symbol must still pull `psycopg` in (so the v1
+    chat-history API keeps working)."""
+    out = _run_python(
+        """
+        import sys
+        import langchain_postgres
+        _ = langchain_postgres.PostgresChatMessageHistory
+        print("psycopg" in sys.modules)
+        """
+    )
+    assert out == "True", (
+        f"psycopg should be imported once the lazy attr is touched; got {out!r}"
+    )


### PR DESCRIPTION
## Description

\`langchain_postgres/__init__.py\` eagerly imports \`chat_message_histories.PostgresChatMessageHistory\`, which top-level imports \`psycopg\` (and \`psycopg.sql\`). So \`from langchain_postgres import PGEngine\` — or anything else from the driver-agnostic v2 API — transitively loads the LGPL-3.0-licensed \`psycopg\`, even for downstreams that only use \`PGEngine\` / \`AsyncPGVectorStore\` / \`Column\` on an Apache-2.0 driver like \`asyncpg\`. As reported in #296, this currently forces those users into a fork or post-install patching step.

This PR moves \`PostgresChatMessageHistory\` behind a module-level \`__getattr__\` so it's only imported when actually accessed. \`PGVector\` (which doesn't directly depend on \`psycopg\`) is unchanged.

This is the minimal of the three options the issue suggested — \"lazy-load the v1 surfaces\". The other two (declaring \`psycopg\` as an optional extra, or splitting the package) are larger and require maintainer direction; this change is a low-risk first step that solves the reported import-side-effect without changing public API.

## Relevant issues

Fixes #296

## Changes

- \`langchain_postgres/__init__.py\`: replace the eager \`from langchain_postgres.chat_message_histories import PostgresChatMessageHistory\` with a module-level \`__getattr__\` that performs the import on first access. \`__all__\` is unchanged so \`PostgresChatMessageHistory\` remains a documented public symbol. A \`TYPE_CHECKING\` import keeps static analyzers happy.
- \`tests/unit_tests/test_lazy_chat_message_histories.py\`: four tests
  - \`PostgresChatMessageHistory\` accessed via the package attribute path resolves to the same class as the direct submodule import (no backward-compat regression);
  - unknown attributes raise \`AttributeError\` (the \`__getattr__\` fallback works);
  - a fresh subprocess that imports only \`PGEngine\` / \`PGVectorStore\` has no \`psycopg\` entry in \`sys.modules\`;
  - the same subprocess does pick up \`psycopg\` once the lazy attribute is touched (so the v1 chat-history API keeps working when needed).

## Testing

\`\`\`
$ python -m pytest tests/unit_tests/test_lazy_chat_message_histories.py -v
4 passed in 2.82s
\`\`\`

Reverting the \`__init__.py\` change while keeping the new tests makes the subprocess test \`test_psycopg_not_imported_when_only_v2_symbols_used\` fail (\`psycopg\` shows up in \`sys.modules\`), confirming the regression coverage pins the buggy behavior. \`ruff check\` and \`ruff format --check\` pass.

## Note

Happy to follow up with the optional-extra approach (option 2 from #296) or a docs note if you'd prefer either alongside this change — let me know.

_Disclaimer: this PR was prepared with the assistance of an AI agent (Claude Code). All code and test changes were reviewed by the author before submission._